### PR TITLE
Allow Argo CD to list configmaps and secrets

### DIFF
--- a/int/argocd/cluster-rbac/argocd-server-clusterrole.yaml
+++ b/int/argocd/cluster-rbac/argocd-server-clusterrole.yaml
@@ -19,6 +19,8 @@ rules:
   - ""
   resources:
   - events
+  - configmaps
+  - secrets
   verbs:
   - list    # supports listing events in UI
 - apiGroups:

--- a/prod/argocd/cluster-rbac/argocd-server-clusterrole.yaml
+++ b/prod/argocd/cluster-rbac/argocd-server-clusterrole.yaml
@@ -19,6 +19,8 @@ rules:
   - ""
   resources:
   - events
+  - configmaps
+  - secrets
   verbs:
   - list    # supports listing events in UI
 - apiGroups:


### PR DESCRIPTION
Argo CD panic due to lock of permission.

![image](https://user-images.githubusercontent.com/1450685/146867006-d298c991-485a-42e3-b8e5-ae37b5df5cd9.png)
