### PR TITLE
Add ks-releaser pipeline into prod cluster

### DIFF
--- a/prod/tekton-pipelines/config/config.json
+++ b/prod/tekton-pipelines/config/config.json
@@ -1,6 +1,6 @@
 {
     "app": {
-        "name": "ks-cli-pipelines-apps",
+        "name": "ks-pipelines-apps",
         "namespace": "ks-devops-ext",
         "path": "prod/tekton-pipelines",
         "clusterName": "in-cluster"

--- a/prod/tekton-pipelines/ks-releaser-pipelines.yaml
+++ b/prod/tekton-pipelines/ks-releaser-pipelines.yaml
@@ -1,0 +1,16 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: ks-releaser-pipelines
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/kubesphere-sigs/ks-releaser
+    targetRevision: HEAD
+    path: .github/tekton
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: ks-devops-ext
+  syncPolicy:
+    automated: {}


### PR DESCRIPTION
### What this PR dose / Why we need it

I have already submitted an another PR https://github.com/kubesphere-sigs/ks-releaser/pull/56 which contains many Tekton manifests, So this PR will allow Argo CD to synchronize those manifests into prod cluster.